### PR TITLE
Add status badges to README and Python classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Ledidi
 
-[![PyPI Downloads](https://static.pepy.tech/badge/Ledidi)](https://pepy.tech/projects/Ledidi)
+[![PyPI version](https://img.shields.io/pypi/v/ledidi.svg)](https://pypi.org/project/ledidi/)
+[![Python versions](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://pypi.org/project/ledidi/)
+[![Tests](https://github.com/jmschrei/ledidi/actions/workflows/test.yml/badge.svg)](https://github.com/jmschrei/ledidi/actions/workflows/test.yml)
+[![Documentation Status](https://readthedocs.org/projects/ledidi/badge/?version=latest)](https://ledidi.readthedocs.io/en/latest/)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/jmschrei/ledidi/blob/master/LICENSE)
+[![PyPI Downloads](https://img.shields.io/pypi/dm/ledidi.svg)](https://pepy.tech/projects/Ledidi)
 
 <img src="https://github.com/user-attachments/assets/500e5f18-f9af-4cc9-b76c-23296d60640d" width="40%" height="40%">
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,14 @@ authors = [
     { name = "Jacob Schreiber", email = "jmschreiber91@gmail.com" },
     { name = "Yang Lu" },
 ]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "torch >= 1.9.0",
     "numpy",


### PR DESCRIPTION
## Summary

Adds a row of status badges to the top of the README and the Python version classifiers that back one of them.

**Badge row** (renders as a single row): PyPI version · Python versions · Tests · Documentation · License · Downloads. The downloads badge is switched from pepy's static badge to the shields.io `pypi/dm` equivalent (still linking to the pepy stats page).

**`pyproject.toml`**: adds `Programming Language :: Python :: 3.9`–`3.13` classifiers so the published package advertises its supported versions (also improves PyPI discoverability). Verified they land in the built wheel metadata.

## Note on the Python-versions badge

The `pypi/pyversions` shields badge reads from the **latest published release's** classifiers, and 2.1.0 was published without them — so it currently renders as "python | missing". To avoid that, the badge is a **static** `python 3.9+` for now. Once a release carries the new classifiers, swap that one line to:

```
https://img.shields.io/pypi/pyversions/ledidi.svg
```

and it will track the metadata automatically.

All badge URLs were verified to resolve (HTTP 200) with correct values. Docs/metadata only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)