### PR TITLE
UPDATE Bump jinja2 docs pin to >=3.1.6 to clear Dependabot alerts

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ matplotlib
 sphinx-rtd-theme
 pandoc
 nbsphinx
-jinja2==3.1.3
+jinja2>=3.1.6


### PR DESCRIPTION
## Summary
Bumps the `jinja2` pin in `docs/requirements.txt` from `==3.1.3` to `>=3.1.6`, clearing all four open Dependabot alerts.

The pin is a **docs-build-only** dependency (transitive via Sphinx); `jinja2` is not part of the `ledidi` runtime dependencies and does not ship in the installed package. All four advisories are medium-severity Jinja2 sandbox-breakout / HTML-injection issues that require rendering untrusted templates — not a path the docs build exercises — so this is housekeeping to keep the security tab clean rather than a runtime fix.

## Alerts cleared
- GHSA-cpwx-vrp4-4pq7 — sandbox breakout via `attr` filter selecting `format`
- GHSA-gmj6-6f8f-6699 — sandbox breakout via malicious filenames
- GHSA-q2x7-8rv6-6q7h — sandbox breakout via indirect `format` reference
- GHSA-h75v-3vvj-5mfj — HTML attribute injection via `xmlattr` filter keys

`3.1.6` is the first release patched against all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)