### PR TITLE
UPDATE Test full Python 3.9-3.13 matrix in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.11", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
Adds **3.10** and **3.12** to the CI matrix so every Python version declared in `pyproject.toml`'s classifiers (and covered by `requires-python = ">=3.9"`) is actually exercised, instead of the previous endpoints-plus-one sampling (3.9 / 3.11 / 3.13).

```diff
- python-version: ["3.9", "3.11", "3.13"]
+ python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
```

The suite is CPU-only and runs in ~10s, so the two extra jobs are cheap and close the gap between claimed and tested support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)