### PR TITLE
ADD input validation across the library via tangermeme

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ledidi
 
 [![PyPI version](https://img.shields.io/pypi/v/ledidi.svg)](https://pypi.org/project/ledidi/)
-[![Python versions](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://pypi.org/project/ledidi/)
+[![Python versions](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://pypi.org/project/ledidi/)
 [![Tests](https://github.com/jmschrei/ledidi/actions/workflows/test.yml/badge.svg)](https://github.com/jmschrei/ledidi/actions/workflows/test.yml)
 [![Documentation Status](https://readthedocs.org/projects/ledidi/badge/?version=latest)](https://ledidi.readthedocs.io/en/latest/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/jmschrei/ledidi/blob/master/LICENSE)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-torch >= 1.9.0
+torch >= 2.0
 matplotlib
 sphinx-rtd-theme
 pandoc

--- a/docs/tutorials/Tutorial_2_-_Constraints_and_Priors.ipynb
+++ b/docs/tutorials/Tutorial_2_-_Constraints_and_Priors.ipynb
@@ -265,42 +265,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "1a781bb7-0e23-47cc-9234-77632e3fbf53",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "iter=I\tinput_loss=0.0\toutput_loss=0.25\ttotal_loss=0.25\ttime=0.0\n",
-      "iter=100\tinput_loss=4.125\toutput_loss=0.01595\ttotal_loss=0.4284\ttime=1.217\n",
-      "iter=F\tinput_loss=1.938\toutput_loss=0.03134\ttotal_loss=0.2251\ttime=1.892\n",
-      "iter=I\tinput_loss=0.0\toutput_loss=0.25\ttotal_loss=0.25\ttime=0.0\n",
-      "iter=100\tinput_loss=1.75\toutput_loss=0.01721\ttotal_loss=0.1922\ttime=1.214\n",
-      "iter=F\tinput_loss=1.75\toutput_loss=0.01373\ttotal_loss=0.1887\ttime=1.905\n",
-      "iter=I\tinput_loss=0.0\toutput_loss=0.25\ttotal_loss=0.25\ttime=0.0\n",
-      "iter=100\tinput_loss=2.125\toutput_loss=0.002378\ttotal_loss=0.2149\ttime=1.161\n",
-      "iter=F\tinput_loss=1.688\toutput_loss=0.02081\ttotal_loss=0.1896\ttime=1.898\n"
-     ]
-    }
-   ],
-   "source": [
-    "torch.manual_seed(0)\n",
-    "X_bar0 = ledidi(model, X_gata, y_bar)\n",
-    "\n",
-    "torch.manual_seed(0)\n",
-    "input_mask = numpy.zeros(2114, dtype=bool)\n",
-    "input_mask[:1057] = True\n",
-    "\n",
-    "X_bar1 = ledidi(model, X_gata, y_bar, input_mask=input_mask)\n",
-    "\n",
-    "torch.manual_seed(0)\n",
-    "input_mask = numpy.zeros(2114, dtype=bool)\n",
-    "input_mask[1057:] = True\n",
-    "\n",
-    "X_bar2 = ledidi(model, X_gata, y_bar, input_mask=input_mask).cuda()"
-   ]
+   "outputs": [],
+   "source": "torch.manual_seed(0)\nX_bar0 = ledidi(model, X_gata, y_bar)\n\ntorch.manual_seed(0)\ninput_mask = torch.zeros(2114, dtype=torch.bool)\ninput_mask[:1057] = True\n\nX_bar1 = ledidi(model, X_gata, y_bar, input_mask=input_mask)\n\ntorch.manual_seed(0)\ninput_mask = torch.zeros(2114, dtype=torch.bool)\ninput_mask[1057:] = True\n\nX_bar2 = ledidi(model, X_gata, y_bar, input_mask=input_mask).cuda()"
   },
   {
    "cell_type": "markdown",

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -6,6 +6,23 @@ Release History
 ===============
 
 
+Version 2.2.0 (unreleased)
+==========================
+
+Highlights
+----------
+
+	- Hardened inputs across the library: :func:`ledidi.ledidi`,
+	  :class:`ledidi.Ledidi`, :func:`ledidi.pruning.greedy_pruning`,
+	  :class:`ledidi.wrappers.DesignWrapper`, and :func:`ledidi.losses.MinGap`
+	  now validate their arguments and raise informative errors for malformed
+	  inputs (non-one-hot sequences, shape and dtype mismatches, non-positive
+	  hyperparameters, and so on) rather than failing deep inside the optimizer.
+	- Tensor validation reuses ``tangermeme.utils._validate_input``, which is now
+	  a dependency.
+	- Raised the minimum supported Python to 3.10 and the minimum PyTorch to 2.0.
+
+
 Version 2.1.0
 =============
 

--- a/ledidi/ledidi.py
+++ b/ledidi/ledidi.py
@@ -3,7 +3,9 @@
 #          adapted from code written by Yang Lu
 
 import time
+
 import torch
+from tangermeme.utils import _validate_input
 
 
 def _gumbel_softmax_hard(logits, tau, dim, generator):
@@ -124,13 +126,13 @@ def ledidi(model, X, y_bar, n_repeats=1, n_samples=None, return_designer=False,
 		from the given model. If a list is provided then each item in the list must
 		have those properties.
 	
-	n_repeats: int, optional
+	n_repeats: int, positive, optional
 		The number of times to run the Ledidi procedure. If 1, do not include this
 		as a dimension in the returned blob of sequences. If above 1, include this
 		as the first or second dimension, depending on whether an affinity catalog
 		is being designed (second if so, first if not). Default is 1.
 	
-	n_samples: int or None, optional
+	n_samples: int or None, positive, optional
 		The number of samples to draw from Ledidi after the optimization process.
 		If None, draw one batch as defined by `batch_size`. Otherwise, draw the
 		number of sequences specified.
@@ -180,12 +182,17 @@ def ledidi(model, X, y_bar, n_repeats=1, n_samples=None, return_designer=False,
 	if n_samples is not None and (not isinstance(n_samples, int) or n_samples <= 0):
 		raise ValueError("n_samples must be a positive integer, not `{}`".format(
 			n_samples))
-	
+
+	_validate_input(X, "X", shape=(1, -1, -1), ohe=True, allow_N=True)
+
 	if not isinstance(y_bar, list):
 		y_bar = [y_bar]
-	
+
+	for i, y_bar_i in enumerate(y_bar):
+		_validate_input(y_bar_i, "y_bar" if len(y_bar) == 1 else "y_bar[{}]".format(i))
+
 	ny = len(y_bar)
-	
+
 	X = X.to(device)
 	X_bar = [[] for i in range(ny)]
 	designers = [[] for i in range(ny)]
@@ -261,7 +268,7 @@ class Ledidi(torch.nn.Module):
         A model to use as an oracle that will be frozen as a part of the
         Ledidi procedure.
 
-    shape: tuple of two integers
+    shape: tuple of two positive integers
         The number of categories and the number of positions, respectively,
         in the sequence to be edited. For nucleotides this might be (4, 1000).
 
@@ -288,34 +295,35 @@ class Ledidi(torch.nn.Module):
         sharper, i.e., more closely match the argmax of each position.
         Default is 1.
 
-    l: float, positive, optional
+    l: float, non-negative, optional
         The mixing weight parameter between the input loss and the output loss,
         applied to the input loss. The smaller this value is the more important
-        it is that the output loss is minimized. Default is 0.1.
+        it is that the output loss is minimized. A value of 0 disables the input
+        loss entirely. Default is 0.1.
 
-    batch_size: int, optional
+    batch_size: int, positive, optional
         The number of sequences to generate at each step and average loss over.
         Default is 16.
 
-    max_iter: int, optional
+    max_iter: int, positive, optional
         The maximum number of iterations to continue generating samples.
         Default is 1000.
 
-    early_stopping_iter: int, optional
+    early_stopping_iter: int, positive, optional
         The number of consecutive iterations without an improvement in the total
         loss to allow before stopping the optimization early. Default is 100.
 
-    report_iter: int, optional
+    report_iter: int, positive, optional
         The number of iterations to perform before reporting results of the
         optimization. Default is 100.
 
-    lr: float, optional
+    lr: float, positive, optional
         The learning rate of the procedure. Default is 1.0.
 
-    input_mask: torch.Tensor or None, shape=(shape[-1],)
-        A mask where 1 indicates what positions cannot be edited. This will 
-        set the initial weights mask to -inf at those positions. If None, no 
-        positions are masked out. Default is None.
+    input_mask: torch.Tensor or None, shape=(shape[-1],), dtype=bool
+        A boolean mask where True indicates what positions cannot be edited.
+        This will set the initial weights mask to -inf at those positions. If
+        None, no positions are masked out. Default is None.
 
     initial_weights: torch.Tensor or None, shape=(1, shape[0], shape[1])
         Initial weights to use in the weight matrix to specify priors in the
@@ -323,7 +331,7 @@ class Ledidi(torch.nn.Module):
         that certain edits are proposed, negative values mean less likely that
         those edits are proposed.
 
-    eps: float, optional
+    eps: float, positive, optional
         The epsilon to add to the one-hot encoding. Because the first step
         of the procedure is to take log(X + eps) the smaller eps is the
         higher a value in the design weight needs to be achieved before
@@ -354,7 +362,56 @@ class Ledidi(torch.nn.Module):
         lr=1.0, input_mask=None, initial_weights=None, eps=1e-4,
         return_history=False, verbose=True, random_state=None):
         super().__init__()
-        
+
+        if not isinstance(model, torch.nn.Module):
+            raise TypeError("model must be a torch.nn.Module, not `{}`".format(
+                type(model)))
+
+        if len(shape) != 2 or any(not isinstance(s, int) or s <= 0
+            for s in shape):
+            raise ValueError("shape must be a tuple of two positive integers, "
+                "not `{}`".format(tuple(shape)))
+
+        if target is not None and not isinstance(target, int):
+            raise TypeError("target must be an integer or None, not `{}`".format(
+                type(target)))
+
+        if tau <= 0:
+            raise ValueError("tau must be positive, not `{}`".format(tau))
+
+        if l < 0:
+            raise ValueError("l must be non-negative, not `{}`".format(l))
+
+        if not isinstance(batch_size, int) or batch_size <= 0:
+            raise ValueError("batch_size must be a positive integer, not "
+                "`{}`".format(batch_size))
+
+        if not isinstance(max_iter, int) or max_iter <= 0:
+            raise ValueError("max_iter must be a positive integer, not "
+                "`{}`".format(max_iter))
+
+        if not isinstance(early_stopping_iter, int) or early_stopping_iter <= 0:
+            raise ValueError("early_stopping_iter must be a positive integer, "
+                "not `{}`".format(early_stopping_iter))
+
+        if not isinstance(report_iter, int) or report_iter <= 0:
+            raise ValueError("report_iter must be a positive integer, not "
+                "`{}`".format(report_iter))
+
+        if lr <= 0:
+            raise ValueError("lr must be positive, not `{}`".format(lr))
+
+        if eps <= 0:
+            raise ValueError("eps must be positive, not `{}`".format(eps))
+
+        if input_mask is not None:
+            _validate_input(input_mask, "input_mask", shape=(shape[-1],),
+                dtype=torch.bool)
+
+        if initial_weights is not None:
+            _validate_input(initial_weights, "initial_weights",
+                shape=(1, shape[0], shape[1]))
+
         for param in model.parameters():
             param.requires_grad = False
             
@@ -413,6 +470,9 @@ class Ledidi(torch.nn.Module):
             passed in.
         """
 
+        _validate_input(X, "X", shape=(1, self.weights.shape[1],
+            self.weights.shape[2]))
+
         logits = torch.log(X + self.eps) + self.weights
         logits = logits.expand(self.batch_size, *(-1 for i in range(X.ndim-1)))
 
@@ -458,8 +518,16 @@ class Ledidi(torch.nn.Module):
             passed in.
         """
 
+        _validate_input(X, "X", shape=(1, self.weights.shape[1],
+            self.weights.shape[2]), ohe=True, allow_N=True)
+
+        _validate_input(y_bar, "y_bar")
+        if y_bar.shape[0] != 1:
+            raise ValueError("y_bar must have a leading dimension of size 1, "
+                "but has shape {}".format(tuple(y_bar.shape)))
+
         optimizer = torch.optim.AdamW((self.weights,), lr=self.lr)
-        history = {'edits': [], 'input_loss': [], 'output_loss': [], 
+        history = {'edits': [], 'input_loss': [], 'output_loss': [],
             'total_loss': [], 'batch_size': self.batch_size}
 
         if self.input_mask is not None:

--- a/ledidi/losses.py
+++ b/ledidi/losses.py
@@ -2,6 +2,7 @@
 # Authors: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import torch
+from tangermeme.utils import _validate_input
 
 
 class MinGap():
@@ -33,10 +34,18 @@ class MinGap():
 		A boolean mask over the `n` outputs from the underlying predictive model.
 		True marks an output as on-target, i.e., one whose value should be
 		maximized, and False marks an output as off-target, i.e., one whose value
-		should be minimized.
+		should be minimized. It must contain at least one on-target (True) and one
+		off-target (False) output, since the loss takes a minimum over the former
+		and a maximum over the latter.
 	"""
 
 	def __init__(self, in_mask):
+		_validate_input(in_mask, "in_mask", dtype=torch.bool)
+
+		if bool(in_mask.all()) or not bool(in_mask.any()):
+			raise ValueError("in_mask must contain at least one on-target "
+				"(True) and one off-target (False) output")
+
 		self.in_mask = in_mask
 
 	def __call__(self, y_hat, y_bar):

--- a/ledidi/pruning.py
+++ b/ledidi/pruning.py
@@ -2,7 +2,9 @@
 # Authors: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import time
+
 import torch
+from tangermeme.utils import _validate_input
 
 @torch.no_grad()
 def greedy_pruning(model, X, X_hat, threshold=1, target=None, verbose=False):
@@ -32,7 +34,7 @@ def greedy_pruning(model, X, X_hat, threshold=1, target=None, verbose=False):
 		A tensor of the same shape as `X` except that it contains the proposed
 		edits.
 
-	threshold: float, optional
+	threshold: float, positive, optional
 		A threshold on the maximum change in model output that removing an edit
 		can have. Default is 1.
 
@@ -50,6 +52,20 @@ def greedy_pruning(model, X, X_hat, threshold=1, target=None, verbose=False):
 		A tensor of the same shape as `X_hat` except with some of the edits
 		reverted back to what they were in `X`.
 	"""
+
+	if not isinstance(model, torch.nn.Module):
+		raise TypeError("model must be a torch.nn.Module, not `{}`".format(
+			type(model)))
+
+	if threshold <= 0:
+		raise ValueError("threshold must be positive, not `{}`".format(threshold))
+
+	if target is not None and not isinstance(target, int):
+		raise TypeError("target must be an integer or None, not `{}`".format(
+			type(target)))
+
+	_validate_input(X, "X", shape=(1, -1, -1), ohe=True, allow_N=True)
+	_validate_input(X_hat, "X_hat", shape=tuple(X.shape), ohe=True, allow_N=True)
 
 	model = model.eval()
 	X_hat = torch.clone(X_hat)

--- a/ledidi/wrappers.py
+++ b/ledidi/wrappers.py
@@ -25,12 +25,26 @@ class DesignWrapper(torch.nn.Module):
 	
 	Parameters
 	----------
-	models: list, tuple
-		A set of torch.nn.Module objects.
+	models: list or tuple
+		A non-empty list or tuple of torch.nn.Module objects.
 	"""
 	
 	def __init__(self, models):
 		super(DesignWrapper, self).__init__()
+
+		if isinstance(models, torch.nn.Module):
+			raise TypeError("models must be a list or tuple of torch.nn.Module "
+				"objects, not a single torch.nn.Module")
+
+		if not isinstance(models, (list, tuple)) or len(models) == 0:
+			raise ValueError("models must be a non-empty list or tuple of "
+				"torch.nn.Module objects")
+
+		for i, model in enumerate(models):
+			if not isinstance(model, torch.nn.Module):
+				raise TypeError("models[{}] must be a torch.nn.Module, not "
+					"`{}`".format(i, type(model)))
+
 		self.models = torch.nn.ModuleList(models)
 
 	def forward(self, X):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ledidi"
 dynamic = ["version"]
 description = "Ledidi is an optimization approach for designing edits to biological sequences."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [
     { name = "Jacob Schreiber", email = "jmschreiber91@gmail.com" },
@@ -15,18 +15,18 @@ authors = [
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "torch >= 1.9.0",
+    "torch >= 2.0",
     "numpy",
     "pandas",
     "matplotlib",
     "logomaker",
+    "tangermeme >= 1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ledidi.py
+++ b/tests/test_ledidi.py
@@ -597,3 +597,152 @@ def test_design_across_tangermeme_models():
 				X_hat2 = ledidi(model2, X, y_bar, random_state=rs,
 					device='cpu', verbose=False, **kwargs)
 				assert torch.equal(X_hat, X_hat2)
+
+
+###
+# Ledidi.__init__ -- input validation
+
+
+def test_ledidi_init_invalid_model():
+	with assert_raises(TypeError):
+		Ledidi("not a model", shape=(4, 12), verbose=False)
+
+
+@pytest.mark.parametrize("shape", [(4,), (4, 12, 1), (4, 0), (4, -1),
+	(4, 12.0)])
+def test_ledidi_init_invalid_shape(model, shape):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=shape, verbose=False)
+
+
+@pytest.mark.parametrize("target", [1.5, "0", [0]])
+def test_ledidi_init_invalid_target(model, target):
+	with assert_raises(TypeError):
+		Ledidi(model, shape=(4, 12), target=target, verbose=False)
+
+
+@pytest.mark.parametrize("tau", [0, -1.0])
+def test_ledidi_init_invalid_tau(model, tau):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), tau=tau, verbose=False)
+
+
+def test_ledidi_init_invalid_l(model):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), l=-0.1, verbose=False)
+
+
+def test_ledidi_init_l_zero_allowed(model):
+	# l is non-negative: 0 disables the input loss and must be accepted.
+	designer = Ledidi(model, shape=(4, 12), l=0, verbose=False)
+	assert designer.l == 0
+
+
+@pytest.mark.parametrize("batch_size", [0, -1, 1.5])
+def test_ledidi_init_invalid_batch_size(model, batch_size):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), batch_size=batch_size, verbose=False)
+
+
+@pytest.mark.parametrize("max_iter", [0, -1, 1.5])
+def test_ledidi_init_invalid_max_iter(model, max_iter):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), max_iter=max_iter, verbose=False)
+
+
+@pytest.mark.parametrize("early_stopping_iter", [0, -1, 1.5])
+def test_ledidi_init_invalid_early_stopping_iter(model, early_stopping_iter):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), early_stopping_iter=early_stopping_iter,
+			verbose=False)
+
+
+@pytest.mark.parametrize("report_iter", [0, -1, 1.5])
+def test_ledidi_init_invalid_report_iter(model, report_iter):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), report_iter=report_iter, verbose=False)
+
+
+@pytest.mark.parametrize("lr", [0, -1.0])
+def test_ledidi_init_invalid_lr(model, lr):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), lr=lr, verbose=False)
+
+
+@pytest.mark.parametrize("eps", [0, -1e-4])
+def test_ledidi_init_invalid_eps(model, eps):
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), eps=eps, verbose=False)
+
+
+def test_ledidi_init_invalid_input_mask_dtype(model):
+	mask = torch.zeros(12, dtype=torch.float32)
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), input_mask=mask, verbose=False)
+
+
+def test_ledidi_init_invalid_input_mask_shape(model):
+	mask = torch.zeros(6, dtype=torch.bool)
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), input_mask=mask, verbose=False)
+
+
+def test_ledidi_init_invalid_initial_weights_shape(model):
+	weights = torch.zeros(1, 4, 6)
+	with assert_raises(ValueError):
+		Ledidi(model, shape=(4, 12), initial_weights=weights, verbose=False)
+
+
+###
+# Ledidi.forward / fit_transform -- input validation
+
+
+def test_ledidi_forward_invalid_shape(model):
+	designer = Ledidi(model, shape=(4, 12), batch_size=4, verbose=False)
+	X = torch.zeros(1, 4, 6)
+	with assert_raises(ValueError):
+		designer(X)
+
+
+def test_ledidi_fit_transform_non_ohe(model, y_bar):
+	designer = Ledidi(model, shape=(4, 12), batch_size=4, verbose=False)
+	X = torch.full((1, 4, 12), 0.25)
+	with assert_raises(ValueError):
+		designer.fit_transform(X, y_bar)
+
+
+def test_ledidi_fit_transform_y_bar_bad_leading_dim(model, X):
+	designer = Ledidi(model, shape=(4, 12), batch_size=4, verbose=False)
+	y_bar = torch.tensor([[5.0, -5.0, 0.0], [5.0, -5.0, 0.0]])
+	with assert_raises(ValueError):
+		designer.fit_transform(X, y_bar)
+
+
+def test_ledidi_fit_transform_allows_N(model, X, y_bar):
+	# An all-zeroes (unknown) column is a valid input and must not be rejected.
+	designer = Ledidi(model, shape=(4, 12), batch_size=4, max_iter=10,
+		random_state=0, verbose=False)
+	X = torch.clone(X)
+	X[0, :, 0] = 0.0
+	designer.fit_transform(X, y_bar)
+
+
+###
+# ledidi() wrapper -- sequence validation
+
+
+def test_ledidi_wrapper_non_ohe(model, y_bar):
+	X = torch.full((1, 4, 12), 0.25)
+	with assert_raises(ValueError):
+		ledidi(model, X, y_bar, device='cpu', verbose=False)
+
+
+def test_ledidi_wrapper_bad_X_shape(model, y_bar):
+	X = torch.zeros(4, 12)
+	with assert_raises(ValueError):
+		ledidi(model, X, y_bar, device='cpu', verbose=False)
+
+
+def test_ledidi_wrapper_non_tensor_y_bar(model, X):
+	with assert_raises(ValueError):
+		ledidi(model, X, [1.0, 2.0, 3.0], device='cpu', verbose=False)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -107,3 +107,22 @@ def test_mingap_gradient(y_hat, in_mask):
 		[0.0, -0.5, 0.5, 0.0]
 	])
 	assert_array_almost_equal(y_hat.grad.numpy(), expected.numpy(), 4)
+
+
+###
+# MinGap -- input validation
+
+
+def test_mingap_in_mask_non_bool():
+	with pytest.raises(ValueError):
+		MinGap(torch.tensor([1, 1, 0, 0]))
+
+
+def test_mingap_in_mask_all_true():
+	with pytest.raises(ValueError):
+		MinGap(torch.tensor([True, True, True, True]))
+
+
+def test_mingap_in_mask_all_false():
+	with pytest.raises(ValueError):
+		MinGap(torch.tensor([False, False, False, False]))

--- a/tests/test_pruning.py
+++ b/tests/test_pruning.py
@@ -101,3 +101,36 @@ def test_greedy_pruning_high_threshold_full_with_target(X, X_hat):
 	# A large threshold prunes every channel-0-relevant edit too.
 	X_m = greedy_pruning(SumModel(), X, X_hat, threshold=10, target=0)
 	assert_array_almost_equal(X_m.numpy(), X.numpy(), 4)
+
+
+###
+# greedy_pruning -- input validation
+
+
+def test_greedy_pruning_invalid_model(X, X_hat):
+	with pytest.raises(TypeError):
+		greedy_pruning("not a model", X, X_hat)
+
+
+@pytest.mark.parametrize("threshold", [0, -1.0])
+def test_greedy_pruning_invalid_threshold(X, X_hat, threshold):
+	with pytest.raises(ValueError):
+		greedy_pruning(SumModel(), X, X_hat, threshold=threshold)
+
+
+def test_greedy_pruning_invalid_target(X, X_hat):
+	with pytest.raises(TypeError):
+		greedy_pruning(SumModel(), X, X_hat, target=1.5)
+
+
+def test_greedy_pruning_non_ohe(X):
+	X_hat = torch.full((1, 4, 6), 0.25)
+	with pytest.raises(ValueError):
+		greedy_pruning(SumModel(), X, X_hat)
+
+
+def test_greedy_pruning_shape_mismatch(X):
+	X_hat = torch.zeros(1, 4, 8)
+	X_hat[0, 0, :] = 1.0
+	with pytest.raises(ValueError):
+		greedy_pruning(SumModel(), X, X_hat)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -93,3 +93,22 @@ def test_designwrapper_gradient_flows(X):
 	wrapper(X).sum().backward()
 	assert X.grad is not None
 	assert X.grad.shape == X.shape
+
+
+###
+# DesignWrapper -- input validation
+
+
+def test_designwrapper_single_model_rejected():
+	with pytest.raises(TypeError):
+		DesignWrapper(SumModel())
+
+
+def test_designwrapper_empty_rejected():
+	with pytest.raises(ValueError):
+		DesignWrapper([])
+
+
+def test_designwrapper_non_module_member_rejected():
+	with pytest.raises(TypeError):
+		DesignWrapper([SumModel(), "not a model"])


### PR DESCRIPTION
## Summary

Hardens every public entry point so malformed inputs are caught at the boundary with an informative error instead of failing deep inside the optimizer. Tensor validation is delegated to `tangermeme.utils._validate_input` (now a dependency) rather than re-vendored; scalar checks are inline alongside the existing `n_repeats`/`n_samples` checks.

### Validation added
- **`ledidi()`** — `X` must be one-hot `(1, C, L)` (all-zero/N columns allowed); each `y_bar` must be a tensor.
- **`Ledidi.__init__`** — `model` is a `Module`; `shape` is two positive ints; `target` is int/None; `tau>0`, `l>=0`, positive-int `batch_size`/`max_iter`/`early_stopping_iter`/`report_iter`, `lr>0`, `eps>0`; `input_mask` is a bool tensor of length `L`; `initial_weights` is `(1, C, L)`.
- **`forward`/`fit_transform`** — shape/one-hot guards; `y_bar` leading dim must be 1.
- **`greedy_pruning`** — `model` is a `Module`; positive `threshold`; int/None `target`; `X`/`X_hat` matching-shape one-hots.
- **`DesignWrapper`** — rejects a single Module, an empty list, or a non-Module member.
- **`MinGap`** — `in_mask` must be bool with at least one on- and one off-target.

### Version floors
`tangermeme` requires Python `>=3.10` and `torch>=2.0`, so ledidi's floors are raised to match across `requires-python`, classifiers, the CI matrix, the README badge, and `docs/requirements.txt`. `tangermeme>=1.2.0` is pinned (the release verified to ship the `allow_N` `_validate_input` contract these checks rely on).

### Docs & tests
- Every docstring aligned with the now-tested contract (`l` non-negative, `input_mask` boolean, `MinGap` needs both groups, positive scalars stated).
- Added a **2.2.0 (unreleased)** entry to `docs/whats_new.rst`.
- Converted Tutorial 2's NumPy `input_mask` to a torch bool tensor to match the validated type.
- 33 new test functions (51 cases) covering every rejection plus the `l=0`/all-N accept paths.

## Test plan
- `python -m pytest tests/` → **131 passed, 16 deselected**.
- `python -m pytest tests/ -m gpu` → **16 passed** (run on a CUDA device).
- Ran the README Quickstart end-to-end and the MinGap/DesignWrapper/pruning patterns; verified PyPI `tangermeme==1.2.0`'s `_validate_input` is byte-identical to the contract the tests assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)