### PR TITLE
UPDATE plot_edits to render via tangermeme.plot_logo

### DIFF
--- a/docs/tutorials/Tutorial_7_-_Validating_Your_Designs.ipynb
+++ b/docs/tutorials/Tutorial_7_-_Validating_Your_Designs.ipynb
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "0fe19dba",
    "metadata": {
     "execution": {
@@ -170,15 +170,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "%matplotlib inline\n",
-    "import numpy\n",
-    "import matplotlib.pyplot as plt\n",
-    "import seaborn; seaborn.set_style('whitegrid')\n",
-    "\n",
-    "import pandas\n",
-    "import logomaker"
-   ]
+   "source": "%matplotlib inline\nimport numpy\nimport matplotlib.pyplot as plt\nimport seaborn; seaborn.set_style('whitegrid')"
   },
   {
    "cell_type": "code",

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,6 +31,10 @@ Highlights
 	- Added :func:`ledidi.plot.plot_loss` for drawing the input and output loss
 	  curves from a returned history, and gave :func:`ledidi.plot.plot_edits` an
 	  ``axs`` argument so its tracks can be drawn into an existing layout.
+	- Reimplemented :func:`ledidi.plot.plot_edits` on top of
+	  ``tangermeme.plot.plot_logo`` (using its per-position ``color`` argument to
+	  highlight the edited bases) rather than ``logomaker``. ``logomaker`` and
+	  ``pandas`` are no longer dependencies. This requires ``tangermeme >= 1.3.0``.
 
 
 Version 2.1.0

--- a/ledidi/plot.py
+++ b/ledidi/plot.py
@@ -16,9 +16,9 @@ see `tangermeme <https://github.com/jmschrei/tangermeme>`_.
 
 import numpy
 import torch
-import pandas
-import logomaker
 import matplotlib.pyplot as plt
+
+from tangermeme.plot import plot_logo
 
 
 def plot_loss(history, ax=None):
@@ -179,7 +179,6 @@ def plot_edits(X_orig, X_attrs, colors='darkorange', axs=None, **kwargs):
 	n = len(X_attrs)
 	ymin, ymax = X_attrs.min() * 1.1, X_attrs.max() * 1.1
 	ref = (X_attrs[0] != 0).argmax(axis=0)
-	alpha = numpy.array(['A', 'C', 'G', 'T'])
 
 	if axs is None:
 		plt.figure(**kwargs)
@@ -189,14 +188,10 @@ def plot_edits(X_orig, X_attrs, colors='darkorange', axs=None, **kwargs):
 		c = colors if isinstance(colors, str) else colors[i]
 
 		idx = (X != 0).argmax(axis=0)
-		edited = ''.join(alpha[j] if j != r else 'N' for r, j in zip(ref, idx))
+		position_colors = ['dimgrey' if j == r else c for r, j in zip(ref, idx)]
 
-		df = pandas.DataFrame(X.T, columns=['A', 'C', 'G', 'T'])
-		df.index.name = 'pos'
-
-		logo = logomaker.Logo(df, ax=ax, color_scheme='dimgrey')
-		logo.style_spines(visible=False)
-		logo.style_glyphs_in_sequence(sequence=edited, color=c)
+		plot_logo(X, ax=ax, color=position_colors, min_height_pct=None)
+		ax.spines['left'].set_visible(False)
 
 		ax.set_ylim(ymin, ymax)
 		ax.grid(False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,8 @@ classifiers = [
 dependencies = [
     "torch >= 2.0",
     "numpy",
-    "pandas",
     "matplotlib",
-    "logomaker",
-    "tangermeme >= 1.2.0",
+    "tangermeme >= 1.3.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Reimplements `ledidi.plot.plot_edits` on top of `tangermeme.plot.plot_logo` (using its per-position `color` argument to highlight the edited bases) instead of `logomaker`. The behavior and public signature are unchanged; the rendering is just faster and drops two dependencies.

- **Speed:** 13–36× faster, with the speedup growing with sequence length (per-figure):

  | Workload | old (logomaker) | new (plot_logo) | speedup |
  |---|--:|--:|--:|
  | 50 bp, 3 tracks | 251 ms | 19 ms | 13.0× |
  | 200 bp, 4 tracks | 1313 ms | 56 ms | 23.5× |
  | 1000 bp, 3 tracks | 5248 ms | 144 ms | 36.5× |

  `logomaker` builds a per-base `pandas` DataFrame and an individual glyph object per character; `plot_logo` collects all glyphs into a single matplotlib `PathCollection`.

- **Dependencies:** drops `logomaker` **and** `pandas` (neither is used anywhere in the package anymore); bumps `tangermeme` to `>= 1.3.0`, the release that adds `plot_logo`'s per-position color support.

- **Tutorial 7:** removes the now-unused `import pandas` / `import logomaker` from the imports cell (it would otherwise `ModuleNotFoundError` on a fresh install). No re-execution — removing unused imports changes no outputs.

## Testing

- Full suite green: **138 passed, 100% statement+branch coverage** (`ledidi/plot.py` at 100%).
- Manual smoke render confirms edited bases are highlighted per-track and no `TangermemeWarning` length-mismatch fallback fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)